### PR TITLE
fix formatter to work properly with range formatting and document for…

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -69,7 +69,7 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
             uncrustify.on('exit', (code) => {
                 logger.dbg('uncrustify exited with status: ' + code);
 
-                if (code !== 0) {
+                if (code < 0) {
                     vsc.window.showErrorMessage('Uncrustify exited with error code: ' + code);
                     reject(code);
                 }
@@ -86,7 +86,7 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
             uncrustify.stderr.on('data', (data) => error += data);
             uncrustify.stderr.on('close', () => logger.dbg('uncrustify exited with error: ' + error));
 
-            uncrustify.stdin.write(document.getText(range));
+            uncrustify.stdin.write((range ? document.getText(range) : document.getText()));
             uncrustify.stdin.end();
         });
     }


### PR DESCRIPTION
…matting both

1. document.getText have override functions non-parameter and
one-parameter, so change code to set range and non-range case
properly.

2. Adding new child process will return new pid 1, so to prevent
error message show in window popup, change error checking condition
to less then zero(which means real error case in waitpid()).

I've checked code works well in my local vscode,
but if this fix is wrong, please revert it.

Signed-off-by: SangHyeon Jade Lee <dltkdgus1764@gmail.com>