### PR TITLE
Allow to override default language map

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,14 @@
                     "default": false,
                     "description": "Activates logs for debugging the extension",
                     "scope": "window"
+                },
+                "uncrustify.langOverrides": {
+                    "type": "object",
+                    "default": {
+                        "apex": "JAVA"
+                    },
+                    "description": "Overrides default language settings for uncrustify. Can be used to support languages not officially supported",
+                    "scope": "window"
                 }
             }
         },

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -97,7 +97,7 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
     }
 };
 
-const langOverrides = vsc.workspace.getConfiguration("uncrustify").get("langOverrides", false);
+const langOverrides = vsc.workspace.getConfiguration("uncrustify").get("langOverrides");
 
 const languageMap = Object.assign(
   {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -97,15 +97,19 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
     }
 };
 
-const languageMap = {
-    'apex': 'JAVA',
-    'c': 'C',
-    'cpp': 'CPP',
-    'csharp': 'CS',
-    'd': 'D',
-    'java': 'JAVA',
-    'objective-c': 'OC',
-    'pawn': 'PAWN',
-    'pde': 'JAVA',
-    'vala': 'VALA'
-};
+const langOverrides = vsc.workspace.getConfiguration("uncrustify").get("langOverrides", false);
+
+const languageMap = Object.assign(
+  {
+    c: "C",
+    cpp: "CPP",
+    csharp: "CS",
+    d: "D",
+    java: "JAVA",
+    "objective-c": "OC",
+    pawn: "PAWN",
+    pde: "JAVA",
+    vala: "VALA"
+  },
+  langOverrides
+);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -100,16 +100,16 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
 const langOverrides = vsc.workspace.getConfiguration("uncrustify").get("langOverrides");
 
 const languageMap = Object.assign(
-  {
-    c: "C",
-    cpp: "CPP",
-    csharp: "CS",
-    d: "D",
-    java: "JAVA",
-    "objective-c": "OC",
-    pawn: "PAWN",
-    pde: "JAVA",
-    vala: "VALA"
-  },
-  langOverrides
+    {
+        c: "C",
+        cpp: "CPP",
+        csharp: "CS",
+        d: "D",
+        java: "JAVA",
+        "objective-c": "OC",
+        pawn: "PAWN",
+        pde: "JAVA",
+        vala: "VALA"
+    },
+    langOverrides
 );


### PR DESCRIPTION
Hi!

I added an ability to override the default language mapping, so anyone can use the extension for any language that is not supported officially but can be handled by supported prettifiers. 

For example, this adds an ability to handle Apex as C instead of Java. This might be useful, as uncrustify has problems with Java class indentation