### PR TITLE
Add 'useReplaceOption' for the document saved as UTF8 with BOM.

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -64,6 +64,13 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
                 args.push('--frag');
             }
 
+            // This option help you if the document saved as UTF8 with BOM, though not able to format it partially.
+            if (util.useReplaceOption()) {
+                args.push('--replace');
+                args.push('--no-backup');
+                args.push(document.fileName);
+            }
+
             let uncrustify = cp.spawn(util.executablePath(), args);
 
             logger.dbg(`launched: ${util.executablePath()} ${args.join(' ')}`);
@@ -91,8 +98,10 @@ export default class Formatter implements vsc.DocumentFormattingEditProvider,
             uncrustify.stderr.on('data', (data) => error += data);
             uncrustify.stderr.on('close', () => logger.dbg('uncrustify exited with error: ' + error));
 
-            uncrustify.stdin.write((document.getText(range)));
-            uncrustify.stdin.end();
+            if (!util.useReplaceOption()) {
+                uncrustify.stdin.write((document.getText(range)));
+                uncrustify.stdin.end();
+            }
         });
     }
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,3 +41,7 @@ export function executablePath() {
 export function configUri() {
     return vsc.Uri.parse('uncrustify://configuration');
 };
+
+export function useReplaceOption() {
+    return vsc.workspace.getConfiguration('uncrustify').get('useReplaceOption');
+}


### PR DESCRIPTION
Hi, I'm a Japanese developer.

I added useReplaceOption because I found out that this extension cause writing BOM twice to the document saved as UTF8 with BOM and I understood this problem is able to avoid if use --replace option.

VSCode will save the document as UTF8 with BOM if Japanese comments are contained in it.

I suppose this problem is derived from not supporting utf8bom encoding in Node.js or vscode.TextDocument.getText function.

Thanks.
