### PR TITLE
Add Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Uncrustify's default config file keeps its version at the top of the file; if th
 ## Changelog
 
 See CHANGELOG.md
+
+## Troubleshooting
+
+* `Format Document` doesn't use Uncrustify when C/C++ extension is installed
+  * In `Settings > Extensions > C/C++`, change `C_Cpp: Formatting` from `Default` to `Disabled`.


### PR DESCRIPTION
The C/C++ extension's formatting must be disabled in order for the uncrustify one to work.
Having this information in the extension README.md should help people figure it out without
having to go through the GitHub issues.
